### PR TITLE
chore: initial version of system-usage endpoint

### DIFF
--- a/Doppler.ReportingApi.Test/Controllers/SummaryControllerTest.cs
+++ b/Doppler.ReportingApi.Test/Controllers/SummaryControllerTest.cs
@@ -105,23 +105,35 @@ namespace Doppler.ReportingApi.Controllers
 
         [Theory]
         [InlineData("test1@test.com", TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518)]
-        public async Task Get_system_usage_should_return_empty_response(string userName, string token)
+        public async Task Get_system_usage_should_return_valid_response(string userName, string token)
         {
             // Arrange
-            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+            var mockConnection = new Mock<DbConnection>();
+
+            mockConnection
+                .SetupDapperAsync(c => c.QueryAsync<SystemUsageSummary>(It.IsAny<string>(), It.IsAny<object>(), null, null, null))
+                .ReturnsAsync(Enumerable.Empty<SystemUsageSummary>());
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            // Act
             var request = new HttpRequestMessage(HttpMethod.Get, $"/{userName}/summary/system-usage")
             {
                 Headers = { { "Authorization", $"Bearer {token}" } }
             };
-
-            // Act
             var response = await client.SendAsync(request);
             var content = await response.Content.ReadAsStringAsync();
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotNull(content);
-            Assert.Equal("{}", content);
         }
     }
 }

--- a/Doppler.ReportingApi/Controllers/SummaryController.cs
+++ b/Doppler.ReportingApi/Controllers/SummaryController.cs
@@ -82,11 +82,11 @@ namespace Doppler.ReportingApi.Controllers
         [ProducesResponseType(typeof(SystemUsageSummary), 200)]
         [Produces("application/json")]
         [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
-        public async Task<SystemUsageSummary> GetSystemUsage(string accountName)
+        public async Task<IActionResult> GetSystemUsage(string accountName)
         {
-            var result = await Task.FromResult(new SystemUsageSummary());
+            var result = await _summaryRepository.GetSystemUsageAsync(accountName);
 
-            return result;
+            return new OkObjectResult(result);
         }
     }
 }

--- a/Doppler.ReportingApi/Infrastructure/ISummaryRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/ISummaryRepository.cs
@@ -8,5 +8,6 @@ namespace Doppler.ReportingApi.Infrastructure
     {
         Task<CampaignsSummary> GetCampaignsSummaryByUserAsync(string userName, DateTime startDate, DateTime endDate);
         Task<SubscribersSummary> GetSubscribersSummaryByUserAsync(string userName, DateTime startDate, DateTime endDate);
+        Task<SystemUsageSummary> GetSystemUsageAsync(string accountName);
     }
 }

--- a/Doppler.ReportingApi/Infrastructure/SummaryRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/SummaryRepository.cs
@@ -92,7 +92,7 @@ namespace Doppler.ReportingApi.Infrastructure
                 var results = await connection.QueryAsync<SystemUsageSummary>(databaseQuery, new { accountName });
                 var result = results.SingleOrDefault();
 
-                return result;
+                return result == null ? new SystemUsageSummary() : result;
             }
         }
     }

--- a/Doppler.ReportingApi/Infrastructure/SummaryRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/SummaryRepository.cs
@@ -76,5 +76,24 @@ namespace Doppler.ReportingApi.Infrastructure
                 return result;
             }
         }
+
+        public async Task<SystemUsageSummary> GetSystemUsageAsync(string accountName)
+        {
+            using (var connection = await _connectionFactory.GetConnection())
+            {
+                var databaseQuery = @"
+                SELECT
+                    HasCampaignCreated AS HasCampaingsCreated,
+                    HasListCreated AS HasListsCreated,
+                    HasCampaignSent AS HasCampaingsSent
+                FROM dbo.[User]
+                WHERE Email = @accountName";
+
+                var results = await connection.QueryAsync<SystemUsageSummary>(databaseQuery, new { accountName });
+                var result = results.SingleOrDefault();
+
+                return result;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Include a summary of the change and which issue is fixed. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes:  Jira Ticket, ie. [DW-1321](https://makingsense.atlassian.net/browse/DW-1321) 

El objetivo del endpoint es determinar si un usuario de doppler realizo algunas de las siguientes acciones:
Envió al menos una campaña
Creo al menos una lista
Creo al menos una campaña.

Se tomo de base el codigo de  [Step Service Doppler](https://github.com/MakingSense/Doppler/blob/develop/Doppler.Application.ControlPanelModule/Services/Classes/StepService.cs) 
Dentro del mismo se ejecuta primero este bloque:

`--Bloque 1: the user has a campaign sent (so he has a list and a campaign created at least)
SELECT TOP (1) 
	IdUser,
	1 AS HasCampaingsCreated,
	1 AS HasListsCreated,
	1 AS HasCampaingsSent 
FROM dbo.Campaign 
WHERE 
	IdUser = @UserId AND 
	IdScheduledTask IS NULL AND 
	IdTestCampaign IS NULL AND 
	(
		(IdTestAB IS NULL AND Status = 5 ) OR 
		(IdTestAB IS NOT NULL AND TestABCategory = 3 AND Status = 5 )
	)`

![image](https://user-images.githubusercontent.com/39057464/144270737-9f060841-eea1-4fc2-a8d6-5d41b11ed404.png)


y en caso de no retornar datos ejecuta este:

`--Bloque 2:  the user has sent a campaign but it was removed in some moment so this information is kept in user table
SELECT TOP (1) 
	[User].IdUser AS IdUser, 
	[User].HasCampaignCreated AS HasCampaingsCreated, 
	[User].HasListCreated AS HasListsCreated, 
	[User].HasCampaignSent AS HasCampaingsSent
FROM dbo.[User]
WHERE [User].IdUser = @UserId`

![image](https://user-images.githubusercontent.com/39057464/144270787-3c6cbfd2-8477-4620-b157-dd504088d6c7.png)

 
A simple vista pareciera ser redundante. pero me gustaria que me confirmen si es correcto utilizar solo el segundo bloque.

### Checklist:

<!-- Por favor, no borrar items del checklist. El tilde significa que "lo hice" o que "puedo confirmar que mis cambios no afectan ese aspecto". -->

- [x] I have paid attention to this PR title and description
- [x] I have performed a self-review of my code
- [x] I have built it locally (or my changes does not affect the build)
- [x] I have checked all tests still run ok at Doppler.ReportingApiTest project
- [x] I have added at least one simple unit test covering the new code
