### PR TITLE
New endpoints to download csv

### DIFF
--- a/Doppler.ReportingApi/Controllers/CampaignController.cs
+++ b/Doppler.ReportingApi/Controllers/CampaignController.cs
@@ -5,13 +5,14 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Doppler.ReportingApi.Controllers
 {
     [Authorize]
     [ApiController]
-    public class CampaignController
+    public class CampaignController : ControllerBase
     {
         private readonly ILogger _logger;
         private readonly ICampaignRepository _campaignRepository;
@@ -99,6 +100,88 @@ namespace Doppler.ReportingApi.Controllers
         }
 
         /// <summary>
+        /// Return a CSV file summarizing the sent campaigns performance of a user.
+        /// </summary>
+        /// <param name="accountName">User name</param>
+        /// <param name="dateFilter">A basic date range filter</param>
+        /// <param name="pagingFilter">Pagination filter (optional, can be ignored for CSV)</param>
+        /// <param name="campaignFilter">Filter object containing optional parameters such as campaign name, type, and from email.</param>
+        /// <remarks>Dates must be valid UtcTime with timezone</remarks>
+        [HttpGet]
+        [Route("{accountName}/campaigns/metrics/sent/csv")]
+        [Produces("text/csv")]
+        [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
+        public async Task<IActionResult> GetDailyCampaignsMetricsCsv(
+            string accountName,
+            [FromQuery] BasicPagingFilter pagingFilter,
+            [FromQuery] BasicDateFilter dateFilter,
+            [FromQuery] BasicCampaignFilter campaignFilter)
+        {
+            DateTime? startDate = dateFilter.StartDate?.UtcDateTime;
+            DateTime? endDate = dateFilter.EndDate?.UtcDateTime;
+            string campaignType = campaignFilter.CampaignType?.ToString();
+
+            var items = await _campaignRepository.GetSentCampaignsMetrics(
+                accountName,
+                pagingFilter.PageNumber,
+                pagingFilter.PageSize,
+                startDate,
+                endDate,
+                campaignFilter.CampaignName,
+                campaignType,
+                campaignFilter.FromEmail
+            );
+
+            var csvBuilder = new StringBuilder();
+            csvBuilder.AppendLine("CampaignName,FromEmail,CampaignType,Subscribers,Sent,DeliveryRate,Opens,OpenRate,Unopens,UnopenRate,Clicks,ClickToOpenRate,Bounces,BounceRate,Unsubscribes,UnsubscribeRate,Spam,SpamRate,Date");
+
+            foreach (var item in items)
+            {
+                csvBuilder.AppendLine(string.Join(",",
+                    EscapeCsv(item.Name),
+                    item.FromEmail,
+                    item.CampaignType,
+                    item.Subscribers,
+                    item.Sent,
+                    item.DlvRate.ToString("0.##"),
+                    item.Opens,
+                    item.OpenRate.ToString("0.##"),
+                    item.Unopens,
+                    item.UnopenRate.ToString("0.##"),
+                    item.Clicks,
+                    item.ClickToOpenRate.ToString("0.##"),
+                    item.Bounces,
+                    item.BounceRate.ToString("0.##"),
+                    item.Unsubscribes,
+                    item.UnsubscribeRate.ToString("0.##"),
+                    item.Spam,
+                    item.SpamRate.ToString("0.##"),
+                    item.UTCScheduleDate.ToString("yyyy-MM-dd")
+                ));
+            }
+
+            var csvBytes = Encoding.UTF8.GetBytes(csvBuilder.ToString());
+            var fileName = $"sent-campaigns-{DateTime.UtcNow:yyyyMMddHHmmss}.csv";
+
+            return File(csvBytes, "text/csv", fileName);
+        }
+
+        /// <summary>
+        /// Escapes CSV values ​​that contain commas, quotes, or line breaks.
+        /// </summary>
+        private static string EscapeCsv(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return "";
+
+            if (value.Contains(",") || value.Contains("\"") || value.Contains("\n"))
+                return $"\"{value.Replace("\"", "\"\"")}\"";
+
+            return value;
+        }
+
+
+        /// <summary>
         /// Return an object summarizing the sent campaingns performance of an user
         /// </summary>
         /// <param name="accountName">User name</param>
@@ -139,6 +222,66 @@ namespace Doppler.ReportingApi.Controllers
             };
 
             return new OkObjectResult(pagedResult);
+        }
+
+        /// <summary>
+        /// Return a CSV file summarizing the monthly campaigns performance of a user.
+        /// </summary>
+        /// <param name="accountName">User name</param>
+        /// <param name="dateFilter">A basic date range filter</param>
+        /// <param name="pagingFilter">Pagination filter (optional, can be ignored for CSV)</param>
+        /// <remarks>Dates must be valid UtcTime with timezone</remarks>
+        [HttpGet]
+        [Route("{accountName}/campaigns/metrics/monthly/csv")]
+        [Produces("text/csv")]
+        [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
+        public async Task<IActionResult> GetMonthlyCampaignsMetricsCsv(
+            string accountName,
+            [FromQuery] BasicPagingFilter pagingFilter,
+            [FromQuery] BasicDateFilter dateFilter)
+        {
+            DateTime? startDate = dateFilter.StartDate?.UtcDateTime;
+            DateTime? endDate = dateFilter.EndDate?.UtcDateTime;
+
+            var items = await _campaignRepository.GetMonthlyCampaignsMetrics(
+                accountName,
+                pagingFilter.PageNumber,
+                pagingFilter.PageSize,
+                startDate,
+                endDate
+            );
+
+            var csvBuilder = new StringBuilder();
+            csvBuilder.AppendLine("Year,Month,CampaignsCount,Subscribers,Sent,DeliveryRate,Opens,OpenRate,Unopens,UnopenRate,Clicks,ClickToOpenRate,Bounces,BounceRate,Unsubscribes,UnsubscribeRate,Spam,SpamRate");
+
+            foreach (var item in items)
+            {
+                csvBuilder.AppendLine(string.Join(",",
+                    item.Year,
+                    item.Month.ToString(),
+                    item.CampaginsCount,
+                    item.Subscribers,
+                    item.Sent,
+                    item.DlvRate.ToString("0.##"),
+                    item.Opens,
+                    item.OpenRate.ToString("0.##"),
+                    item.Unopens,
+                    item.UnopenRate.ToString("0.##"),
+                    item.Clicks,
+                    item.ClickToOpenRate.ToString("0.##"),
+                    item.Bounces,
+                    item.BounceRate.ToString("0.##"),
+                    item.Unsubscribes,
+                    item.UnsubscribeRate.ToString("0.##"),
+                    item.Spam,
+                    item.SpamRate.ToString("0.##")
+                ));
+            }
+
+            var csvBytes = Encoding.UTF8.GetBytes(csvBuilder.ToString());
+            var fileName = $"monthly-campaigns-{DateTime.UtcNow:yyyyMMddHHmmss}.csv";
+
+            return File(csvBytes, "text/csv", fileName);
         }
     }
 }


### PR DESCRIPTION
Se agregan dos nuevos endpoints para decargar los respectivos .csv para reporte de campañas individuales y reporte campañas mensuales. 

Sujeto a modificación, falta a definir por producto algunas cuestiones:
- Columnas
- Traducción de columnas
- Si se descarga la pagina actual o todo

Fixes: <!-- Jira Ticket, ie. [DNP-40](https://makingsense.atlassian.net/browse/DNP-40) -->

### Checklist:

<!-- Por favor, no borrar items del checklist. El tilde significa que "lo hice" o que "puedo confirmar que mis cambios no afectan ese aspecto". -->

- [x] I have paid attention to this PR title and description
- [x] I have performed a self-review of my code
- [ ] I have built it locally (or my changes does not affect the build)
- [ ] I have checked all tests still run ok at Doppler.ReportingApiTest project
- [ ] I have added at least one simple unit test covering the new code


[DNP-40]: https://makingsense.atlassian.net/browse/DNP-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ