### PR TITLE
[DOI-2563] Sent / Delivered metrics

### DIFF
--- a/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
@@ -139,12 +139,12 @@ namespace Doppler.ReportingApi.Infrastructure
                     ,SUM(RPT.[Opens]) [Opens]
                     ,CASE
                         WHEN SUM(RPT.[Sent]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Opens]) * 100.0 / SUM(RPT.[Sent]) AS DECIMAL(10,2))
+                        ELSE CAST(SUM(RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(10,2))
                     END AS [OpenRate]
                     ,SUM(RPT.[Sent]) - SUM(RPT.[Opens]) AS [Unopens]
                     ,CASE
                         WHEN SUM(RPT.[Sent]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Sent] - RPT.[Opens]) * 100.0 / SUM(RPT.[Sent]) AS DECIMAL(10,2))
+                        ELSE CAST(SUM(RPT.[Sent] - RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(10,2))
                     END AS [UnopenRate]
                     ,SUM(RPT.[Clicks]) [Clicks]
                     ,CASE
@@ -176,8 +176,8 @@ namespace Doppler.ReportingApi.Infrastructure
                         ,C.[UTCScheduleDate]
                         ,C.[FromEmail]
                         ,C.[CampaignType]
-                        ,ISNULL(C.[AmountSubscribersToSend],0) [Subscribers]
-                        ,ISNULL(C.[AmountSentSubscribers],0) [Sent]
+                        ,ISNULL(C.[AmountSentSubscribers],0) [Subscribers]
+                        ,(ISNULL(C.[DistinctOpenedMailCount],0) + ISNULL(C.[UnopenedMailCount],0)) AS [Sent]
                         ,ISNULL(C.[DistinctOpenedMailCount],0) [Opens]
                         ,ISNULL(C.[DistinctClickCount],0) [Clicks]
                         ,ISNULL(C.[HardBouncedMailCount],0) [Hard]
@@ -315,12 +315,12 @@ namespace Doppler.ReportingApi.Infrastructure
                     ,SUM(RPT.[Opens]) [Opens]
                     ,CASE
                         WHEN SUM(RPT.[Sent]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Opens]) * 100.0 / SUM(RPT.[Sent]) AS DECIMAL(5,2))
+                        ELSE CAST(SUM(RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(5,2))
                     END AS [OpenRate]
                     ,SUM(RPT.[Sent]) - SUM(RPT.[Opens]) AS [Unopens]
                     ,CASE
                         WHEN SUM(RPT.[Sent]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Sent] - RPT.[Opens]) * 100.0 / SUM(RPT.[Sent]) AS DECIMAL(5,2))
+                        ELSE CAST(SUM(RPT.[Sent] - RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(5,2))
                     END AS [UnopenRate]
                     ,SUM(RPT.[Clicks]) [Clicks]
                     ,CASE
@@ -347,8 +347,8 @@ namespace Doppler.ReportingApi.Infrastructure
                         C.[IdUser]
                         ,C.[IdCampaign]
                         ,C.[UTCScheduleDate]
-                        ,ISNULL(C.[AmountSubscribersToSend],0) [Subscribers]
-                        ,ISNULL(C.[AmountSentSubscribers],0) [Sent]
+                        ,ISNULL(C.[AmountSentSubscribers],0) [Subscribers]
+                        ,(ISNULL(C.[DistinctOpenedMailCount],0) + ISNULL(C.[UnopenedMailCount],0)) AS [Sent]
                         ,ISNULL(C.[DistinctOpenedMailCount],0) [Opens]
                         ,ISNULL(C.[DistinctClickCount],0) [Clicks]
                         ,ISNULL(C.[HardBouncedMailCount],0) [Hard]

--- a/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
@@ -141,7 +141,7 @@ namespace Doppler.ReportingApi.Infrastructure
                         WHEN SUM(RPT.[Sent]) = 0 THEN 0
                         ELSE CAST(SUM(RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(10,2))
                     END AS [OpenRate]
-                    ,SUM(RPT.[Sent]) - SUM(RPT.[Opens]) AS [Unopens]
+                    ,SUM(RPT.[Unopens]) AS [Unopens]
                     ,CASE
                         WHEN SUM(RPT.[Sent]) = 0 THEN 0
                         ELSE CAST(SUM(RPT.[Sent] - RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(10,2))
@@ -179,6 +179,7 @@ namespace Doppler.ReportingApi.Infrastructure
                         ,ISNULL(C.[AmountSentSubscribers],0) [Subscribers]
                         ,(ISNULL(C.[DistinctOpenedMailCount],0) + ISNULL(C.[UnopenedMailCount],0)) AS [Sent]
                         ,ISNULL(C.[DistinctOpenedMailCount],0) [Opens]
+                        ,ISNULL(C.[UnopenedMailCount], 0) [Unopens]
                         ,ISNULL(C.[DistinctClickCount],0) [Clicks]
                         ,ISNULL(C.[HardBouncedMailCount],0) [Hard]
                         ,ISNULL (C.[SoftBouncedMailCount],0) [Soft]
@@ -305,7 +306,7 @@ namespace Doppler.ReportingApi.Infrastructure
                     RPT.[IdUser]
                     ,YEAR(dateadd(MINUTE, @timezone, UTCScheduleDate)) [Year]
                     ,MONTH(dateadd(MINUTE, @timezone, UTCScheduleDate)) [Month]
-                    ,COUNT(RPT.[IdCampaign]) [CampaginsCount]
+                    ,COUNT(DISTINCT RPT.[IdCampaign]) [CampaginsCount]
                     ,SUM(RPT.[Subscribers]) [Subscribers]
                     ,SUM(RPT.[Sent]) [Sent]
                     ,CASE
@@ -317,7 +318,7 @@ namespace Doppler.ReportingApi.Infrastructure
                         WHEN SUM(RPT.[Sent]) = 0 THEN 0
                         ELSE CAST(SUM(RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(5,2))
                     END AS [OpenRate]
-                    ,SUM(RPT.[Sent]) - SUM(RPT.[Opens]) AS [Unopens]
+                    ,SUM(RPT.[Unopens]) AS [Unopens]
                     ,CASE
                         WHEN SUM(RPT.[Sent]) = 0 THEN 0
                         ELSE CAST(SUM(RPT.[Sent] - RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(5,2))
@@ -348,8 +349,9 @@ namespace Doppler.ReportingApi.Infrastructure
                         ,C.[IdCampaign]
                         ,C.[UTCScheduleDate]
                         ,ISNULL(C.[AmountSentSubscribers],0) [Subscribers]
-                        ,(ISNULL(C.[DistinctOpenedMailCount],0) + ISNULL(C.[UnopenedMailCount],0)) AS [Sent]
+                        ,(ISNULL(C.AmountSentSubscribers, 0) - (ISNULL(C.HardBouncedMailCount, 0) + ISNULL(C.SoftBouncedMailCount, 0))) AS [Sent]
                         ,ISNULL(C.[DistinctOpenedMailCount],0) [Opens]
+                        ,ISNULL(C.[UnopenedMailCount], 0) [Unopens]
                         ,ISNULL(C.[DistinctClickCount],0) [Clicks]
                         ,ISNULL(C.[HardBouncedMailCount],0) [Hard]
                         ,ISNULL(C.[SoftBouncedMailCount],0) [Soft]
@@ -375,6 +377,7 @@ namespace Doppler.ReportingApi.Infrastructure
                         ,0 [Subscribers]
                         ,0 [Sent]
                         ,0 [Opens]
+                        ,0 [Unopens]
                         ,0 [Clicks]
                         ,0 [Hard]
                         ,0 [Soft]


### PR DESCRIPTION
Observando como trabajan los SP se realizan las siguientes modificaciones:

**En lo que respecta a nuestro reporte campañas (GetSentCampaignsMetrics):**
Se deja de calcular los Sent de esta forma:
`SUM(RPT.[Sent]) - SUM(RPT.[Opens]) AS [Unopens]` pasando a usar la columna correspondiente `UnopenedMailCount`

Los enviados son calculados:
`ISNULL(C.[AmountSentSubscribers],0) [Subscribers]`

Y los entregados:
`(ISNULL(C.[DistinctOpenedMailCount],0) + ISNULL(C.[UnopenedMailCount],0)) AS [Sent]`

--------------------

En el caso del reporte mensual, respetando los SPs originales:
También usamos `UnopenedMailCount`

Uso `COUNT(DISTINCT RPT.[IdCampaign]) [CampaginsCount]` porque el dataset combina Campaign + Subscriber con UNION ALL, lo que genera filas duplicadas por campaña cuando hay desuscripciones/spam. Esto inflaba el conteo de campañas enviadas. El DISTINCT garantiza que cada campaña se cuente solo una vez.

Los enviados son calculados de igual forma que en el historico de campañas:
`ISNULL(C.[AmountSentSubscribers],0) [Subscribers]`

Y los entregados:
`(ISNULL(C.AmountSentSubscribers, 0) - (ISNULL(C.HardBouncedMailCount, 0) + ISNULL(C.SoftBouncedMailCount, 0))) AS [Sent]`

------------------------

Llamo a debate respecto a los entregados ya que ambos SPs originalmente siempre calcularon esto de formas distintas.
`[SR_CampaignsSent_HistoricalReport]`:
<img width="547" height="66" alt="image" src="https://github.com/user-attachments/assets/2618b686-9946-4c37-93a9-287d7e6a7e13" />

`[SR_SummaryByMonth_V2]`:
<img width="638" height="72" alt="image" src="https://github.com/user-attachments/assets/a66af38d-dac5-44ad-96e3-a25baa38ca67" />

Capaz esto forma parte de una decision antigua y esta bien que sea así. Quizás es hora de ajustarlo, si podemos hablarlo buenisimo.

A simple vista pareciera lo mismo, ya que en la primera imagen se toma por entregado a la suma de ABIERTOS + NO ABIERTOS. Y en la segunda imagen se calcula considerando AmountSentSubscribers (que es la suma de abiertos + no abiertos + rebotes) restandole por separado los rebotes (`- (SUM(HardBouncedMailCount) + SUM(SoftBouncedMailCount)`). A pesar que desde la lectura pareciera dar lo mismo, la realidad es que no.

Comparto la parte del SP `[CampaignSentUpdate]` donde ocurren estas sumarizaciones:

<img width="671" height="838" alt="image" src="https://github.com/user-attachments/assets/2fe68073-f3b2-4ea3-8209-93bfa1a93e61" />

Se observa que para calcular `UnopenedMailCount` el IdDeliveryStatus tiene que ser 0
En `DistinctOpenedMailCount` el IdDeliveryStatus tiene que ser 100
Y el `AmountSentSubscribers` es todos los IdDeliveryStatus distintos de 101.

Para mi en esto último radica la diferencia más grande, porque quizás se estan sumando estados que no debería contemplarse (o si):

<img width="339" height="201" alt="image" src="https://github.com/user-attachments/assets/57996268-c5c4-4331-b88e-a3d3b431ba8d" />

----------------

Comparto dos capturas, una de la grilla y de la exportación para que quede claro que la exportación coincide con lo que se visualiza:

<img width="1295" height="2219" alt="SR_CampaignsSent_HistoricalReport" src="https://github.com/user-attachments/assets/a1698114-a5a1-408f-87f6-0a236272df0d" />
<img width="1160" height="714" alt="SR_SummaryByMonth_V2" src="https://github.com/user-attachments/assets/5b5ecf8c-16df-4dae-af2f-664ad9921715" />


Fixes: <!-- Jira Ticket, ie. [DNP-40](https://makingsense.atlassian.net/browse/DNP-40) -->

### Checklist:

<!-- Por favor, no borrar items del checklist. El tilde significa que "lo hice" o que "puedo confirmar que mis cambios no afectan ese aspecto". -->

- [x] I have paid attention to this PR title and description
- [x] I have performed a self-review of my code
- [x] I have built it locally (or my changes does not affect the build)
- [x] I have checked all tests still run ok at Doppler.ReportingApiTest project
- [x] I have added at least one simple unit test covering the new code


[DNP-40]: https://makingsense.atlassian.net/browse/DNP-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ