### PR TITLE
[DOI-2602] Fix dividend case condition

### DIFF
--- a/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
@@ -139,12 +139,12 @@ namespace Doppler.ReportingApi.Infrastructure
                     END AS [DlvRate]
                     ,SUM(RPT.[Opens]) [Opens]
                     ,CASE
-                        WHEN SUM(RPT.[Sent]) = 0 THEN 0
+                        WHEN SUM(RPT.[Subscribers]) = 0 THEN 0
                         ELSE CAST(SUM(RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(10,2))
                     END AS [OpenRate]
                     ,SUM(RPT.[Unopens]) AS [Unopens]
                     ,CASE
-                        WHEN SUM(RPT.[Sent]) = 0 THEN 0
+                        WHEN SUM(RPT.[Subscribers]) = 0 THEN 0
                         ELSE CAST(SUM(RPT.[Sent] - RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(10,2))
                     END AS [UnopenRate]
                     ,SUM(RPT.[Clicks]) [Clicks]
@@ -328,12 +328,12 @@ namespace Doppler.ReportingApi.Infrastructure
                     END AS [DlvRate]
                     ,SUM(RPT.[Opens]) [Opens]
                     ,CASE
-                        WHEN SUM(RPT.[Sent]) = 0 THEN 0
+                        WHEN SUM(RPT.[Subscribers]) = 0 THEN 0
                         ELSE CAST(SUM(RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(5,2))
                     END AS [OpenRate]
                     ,SUM(RPT.[Unopens]) AS [Unopens]
                     ,CASE
-                        WHEN SUM(RPT.[Sent]) = 0 THEN 0
+                        WHEN SUM(RPT.[Subscribers]) = 0 THEN 0
                         ELSE CAST(SUM(RPT.[Sent] - RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(5,2))
                     END AS [UnopenRate]
                     ,SUM(RPT.[Clicks]) [Clicks]


### PR DESCRIPTION
Estaba mal el case, el dividendo es Subscribers y se estaba usando Sent.
El dividendo de: Open, Not Open y Bounces debe ser el mismo para poder calcular bien los porcentajes y la suma de los 3 de 100%.
Por las dudas que surja la duda, hay que usar Subscribers que corresponde a nuestros enviados: abiertos, no abiertos y rebotes.

Se detecto el problema por unos logs en loggly sobre las cuentas de `mmosquera@makingsense.com` y `llopez+int1_paid1@makingsense.com`

Fixes: <!-- Jira Ticket, ie. [DNP-40](https://makingsense.atlassian.net/browse/DNP-40) -->

### Checklist:

<!-- Por favor, no borrar items del checklist. El tilde significa que "lo hice" o que "puedo confirmar que mis cambios no afectan ese aspecto". -->

- [x] I have paid attention to this PR title and description
- [x] I have performed a self-review of my code
- [ ] I have built it locally (or my changes does not affect the build)
- [ ] I have checked all tests still run ok at Doppler.ReportingApiTest project
- [ ] I have added at least one simple unit test covering the new code


[DNP-40]: https://makingsense.atlassian.net/browse/DNP-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ