### PR TITLE
[DOI-2644] Use coalesce for amountsentsubscribers null value

### DIFF
--- a/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
@@ -45,7 +45,7 @@ namespace Doppler.ReportingApi.Infrastructure
                             DATEADD(MINUTE, @timezone, C.[UTCScheduleDate])
                             AS DATE
                         ) AS [Date]
-                        ,ISNULL(C.[AmountSentSubscribers],0) [Sent]
+                        ,COALESCE(C.[AmountSentSubscribers], C.[AmountSubscribersToSend], 0) AS [Sent]
                         ,ISNULL(C.[DistinctOpenedMailCount],0) [Opens]
                         ,ISNULL(C.[DistinctClickCount],0) [Clicks]
                         ,ISNULL(C.[HardBouncedMailCount],0) [Hard]


### PR DESCRIPTION
Cuando una campaña esta en estado 10 (enviando), no tiene AmountSentSubscribers aún, por lo que el valor de la columna queda en NULL. Con este fix, cuando el valor es NULL usamos momentaneamente AmountSubscribersToSend

Fixes: <!-- Jira Ticket, ie. [DNP-40](https://makingsense.atlassian.net/browse/DNP-40) -->

### Checklist:

<!-- Por favor, no borrar items del checklist. El tilde significa que "lo hice" o que "puedo confirmar que mis cambios no afectan ese aspecto". -->

- [x] I have paid attention to this PR title and description
- [x] I have performed a self-review of my code
- [x] I have built it locally (or my changes does not affect the build)
- [x] I have checked all tests still run ok at Doppler.ReportingApiTest project
- [x] I have added at least one simple unit test covering the new code


[DNP-40]: https://makingsense.atlassian.net/browse/DNP-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ