### PR TITLE
[DOI-2688] Normalizing information using SP

### DIFF
--- a/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
@@ -137,18 +137,6 @@ namespace Doppler.ReportingApi.Infrastructure
         {
             using (var connection = _connectionFactory.GetConnection())
             {
-                string getIdUserSql = @"
-                    SELECT TOP 1 U.IdUser
-                    FROM dbo.[User] U WITH (NOLOCK)
-                    WHERE U.[Email] = @userName;";
-
-                var idUser = await connection.QuerySingleOrDefaultAsync<int?>(getIdUserSql, new { userName });
-
-                if (idUser == null)
-                {
-                    return new List<SentCampaignMetrics>();
-                }
-
                 var labelsStr = (labels != null && labels.Count > 0)
                     ? string.Join(",", labels)
                     : null;
@@ -157,7 +145,7 @@ namespace Doppler.ReportingApi.Infrastructure
                     "[dbo].[CampaignsSent_CampaignsMetrics]",
                     new
                     {
-                        id = idUser.Value,
+                        userName,
                         startdate = startDate,
                         enddate = endDate,
                         campaignName,
@@ -218,23 +206,11 @@ namespace Doppler.ReportingApi.Infrastructure
         {
             using (var connection = _connectionFactory.GetConnection())
             {
-                const string getIdUserSql = @"
-                SELECT TOP 1 U.IdUser
-                FROM dbo.[User] U WITH (NOLOCK)
-                WHERE U.[Email] = @userName;";
-
-                var idUser = await connection.QuerySingleOrDefaultAsync<int?>(getIdUserSql, new { userName });
-
-                if (idUser == null)
-                {
-                    return new List<MonthlyCampaignMetrics>();
-                }
-
                 var results = await connection.QueryAsync<MonthlyCampaignMetrics>(
                     "[dbo].[CampaignsSent_CampaignsByMonthMetrics]",
                     new
                     {
-                        id = idUser.Value,
+                        userName,
                         startdate = startDate,
                         enddate = endDate,
                         pageNumber,

--- a/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/CampaignRepository.cs
@@ -124,157 +124,50 @@ namespace Doppler.ReportingApi.Infrastructure
             }
         }
 
-        public async Task<List<SentCampaignMetrics>> GetSentCampaignsMetrics(string userName, int pageNumber, int pageSize, DateTime? startDate = null, DateTime? endDate = null, string campaignName = null, string campaignType = null, string fromEmail = null, List<int> labels = null)
+        public async Task<List<SentCampaignMetrics>> GetSentCampaignsMetrics(
+            string userName,
+            int pageNumber,
+            int pageSize,
+            DateTime? startDate = null,
+            DateTime? endDate = null,
+            string campaignName = null,
+            string campaignType = null,
+            string fromEmail = null,
+            List<int> labels = null)
         {
-            var labelsCount = labels?.Count ?? 0;
-
             using (var connection = _connectionFactory.GetConnection())
             {
-                var dummyDatabaseQuery = @"
-                DECLARE @timezone INT
-                DECLARE @idUser INT
+                string getIdUserSql = @"
+                    SELECT TOP 1 U.IdUser
+                    FROM dbo.[User] U WITH (NOLOCK)
+                    WHERE U.[Email] = @userName;";
 
-                SELECT
-                    @timezone = offset
-                    ,@idUser = u.IdUser
-                FROM dbo.usertimezone timezone
-                INNER JOIN dbo.[user] u ON u.idusertimezone = timezone.idusertimezone
-                WHERE u.[Email] = @userName;
+                var idUser = await connection.QuerySingleOrDefaultAsync<int?>(getIdUserSql, new { userName });
 
-                SELECT
-                    RPT.[IdUser]
-                    ,RPT.[IdCampaign]
-                    ,RPT.[Name]
-                    ,dateadd(MINUTE, @timezone, RPT.[UTCSentDate]) AS [UTCSentDate]
-                    ,RPT.[FromEmail]
-                    ,RPT.[CampaignType]
-                    ,RPT.[IdTestAB]
-                    ,SUM(RPT.[Subscribers]) [Subscribers]
-                    ,SUM(RPT.[Sent]) [Sent]
-                    ,CASE
-                        WHEN SUM(RPT.[Subscribers]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Sent]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(10,2))
-                    END AS [DlvRate]
-                    ,SUM(RPT.[Opens]) [Opens]
-                    ,CASE
-                        WHEN SUM(RPT.[Subscribers]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(10,2))
-                    END AS [OpenRate]
-                    ,SUM(RPT.[Unopens]) AS [Unopens]
-                    ,CASE
-                        WHEN SUM(RPT.[Subscribers]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Sent] - RPT.[Opens]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(10,2))
-                    END AS [UnopenRate]
-                    ,SUM(RPT.[Clicks]) [Clicks]
-                    ,CASE
-                        WHEN SUM(RPT.[Opens]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Clicks]) * 100.0 / SUM(RPT.[Opens]) AS DECIMAL(10,2))
-                    END AS [ClickToOpenRate]
-                    ,SUM(RPT.[Hard] + RPT.[Soft]) [Bounces]
-                    ,CASE
-                        WHEN SUM(RPT.[Subscribers]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Hard] + RPT.[Soft]) * 100.0 / SUM(RPT.[Subscribers]) AS DECIMAL(10,2))
-                    END AS [BounceRate]
-                    ,SUM(RPT.[Unsubscribes]) [Unsubscribes]
-                    ,CASE
-                        WHEN SUM(RPT.[Sent]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Unsubscribes]) * 100.0 / SUM(RPT.[Sent]) AS DECIMAL(10,2))
-                    END AS [UnsubscribeRate]
-                    ,SUM(RPT.[Spam]) [Spam]
-                    ,CASE
-                        WHEN SUM(RPT.[Sent]) = 0 THEN 0
-                        ELSE CAST(SUM(RPT.[Spam]) * 100.0 / SUM(RPT.[Sent]) AS DECIMAL(10,2))
-                    END AS [SpamRate]
-                    ,RPT.[LabelName]
-                    ,RPT.[LabelColour]
-                FROM(
-                    SELECT
-                        C.[IdUser]
-                        ,C.[IdCampaign]
-                        ,C.[Name]
-                        ,C.[UTCSentDate]
-                        ,C.[FromEmail]
-                        ,C.[CampaignType]
-                        ,C.[IdTestAB]
-                        ,ISNULL(C.[AmountSentSubscribers],0) [Subscribers]
-                        ,(ISNULL(C.[DistinctOpenedMailCount],0) + ISNULL(C.[UnopenedMailCount],0)) AS [Sent]
-                        ,ISNULL(C.[DistinctOpenedMailCount],0) [Opens]
-                        ,ISNULL(C.[UnopenedMailCount], 0) [Unopens]
-                        ,ISNULL(C.[DistinctClickCount],0) [Clicks]
-                        ,ISNULL(C.[HardBouncedMailCount],0) [Hard]
-                        ,ISNULL (C.[SoftBouncedMailCount],0) [Soft]
-                        ,ISNULL(C.[UnsubscriptionsCount], Unsubscribes.Unsubscribes) [Unsubscribes]
-                        ,Unsubscribes.Spam [Spam]
-                        ,L.[Name] [LabelName]
-                        ,LC.[Colour] [LabelColour]
-                    FROM [dbo].[Campaign] C WITH (NOLOCK)
-                    JOIN [dbo].[User] U WITH (NOLOCK)
-                        ON C.[IdUser] = U.[IdUser]
-                    LEFT JOIN [dbo].[Label] L WITH (NOLOCK)
-                        ON C.[IdLabel] = L.[IdLabel]
-                    LEFT JOIN [dbo].[Colour] LC WITH (NOLOCK)
-                        ON L.[IdColour] = LC.[IdColour]
-                    LEFT JOIN (
-                        SELECT
-                            COUNT(
-                                CASE
-                                    WHEN S.IdUnsubscriptionReason <> 2
-                                        AND S.UnsubscriptionSubreason NOT IN (2,3,4)
-                                    THEN 1
-                                END
-                            ) [Unsubscribes]
-                            ,COUNT(
-                                CASE
-                                    WHEN S.IdUnsubscriptionReason = 2
-                                        OR S.UnsubscriptionSubreason IN (2,3,4)
-                                    THEN 1
-                                END
-                            ) [Spam]
-                            ,c.IdCampaign
-                        FROM dbo.campaign c
-                        INNER JOIN dbo.subscriber s ON c.idcampaign = s.IdCampaign
-                        WHERE c.iduser = @idUser
-                            AND c.STATUS in (5, 9)
-                            AND c.IdTestCampaign IS NULL
-                            AND s.IdSubscribersStatus = 5
-                        GROUP BY c.IdCampaign
-                    ) Unsubscribes ON c.idcampaign = Unsubscribes.IdCampaign
-                    WHERE
-                        U.[Email] = @userName
-                        AND C.[Status] IN (5,9)
-                        AND C.Active = 1
-                        AND (@startDate IS NULL OR C.[UTCSentDate] >= @startDate)
-                        AND (@endDate IS NULL OR C.[UTCSentDate] < @endDate)
-                        AND (@campaignName IS NULL OR LOWER(LTRIM(RTRIM(C.[Name]))) LIKE '%' + LOWER(LTRIM(RTRIM(@campaignName))) + '%')
-                        AND (
-                                @campaignType IS NULL
-                                OR (LTRIM(RTRIM(@campaignType)) = '')
-                                OR (@campaignType = 'TEST_AB' AND C.IdTestAB IS NOT NULL)
-                                OR (C.CampaignType = @campaignType AND C.IdTestAB IS NULL)
-                        )
-                        AND (@fromEmail IS NULL OR LOWER(LTRIM(RTRIM(C.[FromEmail]))) LIKE LOWER(LTRIM(RTRIM(@fromEmail))))
-                        AND C.[IdTestCampaign] IS NULL
-                        AND C.[IdScheduledTask] IS NULL
-                        AND (C.TestABCategory IS NULL OR C.TestABCategory = 3)
-                        AND (
-                            @labelsCount = 0
-                            OR C.[IdLabel] IN @labels
-                        )
-                ) RPT
-                GROUP BY RPT.[IdUser]
-                        ,RPT.[IdCampaign]
-                        ,RPT.[Name]
-                        ,RPT.[UTCSentDate]
-                        ,RPT.[FromEmail]
-                        ,RPT.[CampaignType]
-                        ,RPT.[IdTestAB]
-                        ,RPT.[LabelName]
-                        ,RPT.[LabelColour]
-                ORDER BY RPT.[UTCSentDate] DESC
-                OFFSET @pageNumber * @pageSize ROWS
-                FETCH NEXT @pageSize ROWS ONLY";
+                if (idUser == null)
+                {
+                    return new List<SentCampaignMetrics>();
+                }
 
-                var results = await connection.QueryAsync<SentCampaignMetrics>(dummyDatabaseQuery, new { userName, pageNumber, pageSize, startDate, endDate, campaignName, campaignType, fromEmail, labelsCount, labels });
+                var labelsStr = (labels != null && labels.Count > 0)
+                    ? string.Join(",", labels)
+                    : null;
+
+                var results = await connection.QueryAsync<SentCampaignMetrics>(
+                    "[dbo].[CampaignsSent_CampaignsMetrics]",
+                    new
+                    {
+                        id = idUser.Value,
+                        startdate = startDate,
+                        enddate = endDate,
+                        campaignName,
+                        campaignType,
+                        fromEmail,
+                        labels = labelsStr,
+                        pageNumber,
+                        pageSize
+                    },
+                    commandType: System.Data.CommandType.StoredProcedure);
 
                 return results.ToList();
             }


### PR DESCRIPTION
Traslade la lógica de los métodos encargados de poblar las grillas del historial de campañas enviadas y la mensual. Ahora los nuevos SP se llaman:

`[dbo].[CampaignsSent_CampaignsMetrics]` y `[dbo].[CampaignsSent_CampaignsByMonthMetrics]`

@fgchaio tuve que realizar ajustes que tocaste en otros PR's, deberías mergear primero lo tuyo, porque acá estoy usando `UTCSentDate` ya.

- [x] I have paid attention to this PR title and description
- [x] I have performed a self-review of my code
- [ ] I have built it locally (or my changes does not affect the build)
- [x] I have checked all tests still run ok at Doppler.ReportingApiTest project
- [ ] I have added at least one simple unit test covering the new code
