### PR TITLE
[DOI-3128] New endpoint assisted sales

### DIFF
--- a/Doppler.ReportingApi.Test/Controllers/SummaryControllerTest.cs
+++ b/Doppler.ReportingApi.Test/Controllers/SummaryControllerTest.cs
@@ -103,6 +103,44 @@ namespace Doppler.ReportingApi.Controllers
         }
 
         [Fact]
+        public async Task Get_summary_assistedsales_should_return_valid_response()
+        {
+            // Arrange
+            var userName = "test1@test.com";
+            var token = TestJwtTokenFactory.ValidAccount123Test1;
+            var mockConnection = new Mock<DbConnection>();
+
+            mockConnection
+                .SetupDapperAsync(c => c.QueryAsync<AssistedSalesSummaryItem>(It.IsAny<string>(), It.IsAny<object>(), null, null, null))
+                .ReturnsAsync(Enumerable.Empty<AssistedSalesSummaryItem>());
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.SetupConnectionFactory(mockConnection.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var startDate = DateTime.Today.AddDays(-30);
+            var endDate = DateTime.Today;
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/{userName}/summary/assistedsales?startDate={startDate.ToLongDateString()}&endDate={endDate.ToLongTimeString()}")
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
+            Assert.NotNull(content);
+        }
+
+        [Fact]
         public async Task Get_system_usage_should_return_valid_response()
         {
             // Arrange

--- a/Doppler.ReportingApi/Controllers/SummaryController.cs
+++ b/Doppler.ReportingApi/Controllers/SummaryController.cs
@@ -72,6 +72,31 @@ namespace Doppler.ReportingApi.Controllers
             return new OkObjectResult(result);
         }
 
+        /// <summary>
+        /// Return assisted sales stats for an user
+        /// </summary>
+        /// <param name="accountName">User name</param>
+        /// <param name="dateFilter">A basic date range filter </param>
+        /// <remarks>Dates must be valid UtcTime with timezone</remarks>
+        [HttpGet]
+        [Route("{accountName}/summary/assistedsales")]
+        [ProducesResponseType(typeof(IEnumerable<AssistedSalesSummaryItem>), 200)]
+        [Produces("application/json")]
+        [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
+        public async Task<IActionResult> GetAssistedSales(string accountName, [FromQuery] BasicDateFilter dateFilter)
+        {
+            if (!dateFilter.StartDate.HasValue || !dateFilter.EndDate.HasValue)
+            {
+                return new BadRequestObjectResult("StartDate and EndDate are required fields");
+            }
+
+            var startDate = dateFilter.StartDate.Value.UtcDateTime;
+            var endDate = dateFilter.EndDate.Value.UtcDateTime;
+            var result = await _summaryRepository.GetAssistedSalesAsync(accountName, startDate, endDate);
+
+            return new OkObjectResult(result);
+        }
+
         #region Home Dashboard
 
         #region Audience

--- a/Doppler.ReportingApi/Infrastructure/ISummaryRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/ISummaryRepository.cs
@@ -9,6 +9,7 @@ namespace Doppler.ReportingApi.Infrastructure
     {
         Task<CampaignsSummary> GetCampaignsSummaryByUserAsync(string userName, DateTime startDate, DateTime endDate);
         Task<SubscribersSummary> GetSubscribersSummaryByUserAsync(string userName, DateTime startDate, DateTime endDate);
+        Task<IEnumerable<AssistedSalesSummaryItem>> GetAssistedSalesAsync(string accountName, DateTime startDate, DateTime endDate);
         Task<IEnumerable<SubscriberStatusStat>> GetSubscribersDashboardByUserAsync(string userName, DateTime startDate, DateTime endDate);
         Task<IEnumerable<EmailCampaignDashboardItem>> GetEmailCampaignsAsync(string accountName, DateTime startDate, DateTime endDate, string campaignType);
         Task<WebsiteActivityRfmDashboard> GetWebsiteActivityRfmAsync(string accountName);

--- a/Doppler.ReportingApi/Infrastructure/SummaryRepository.cs
+++ b/Doppler.ReportingApi/Infrastructure/SummaryRepository.cs
@@ -87,6 +87,53 @@ namespace Doppler.ReportingApi.Infrastructure
             }
         }
 
+        public async Task<IEnumerable<AssistedSalesSummaryItem>> GetAssistedSalesAsync(
+            string accountName,
+            DateTime startDate,
+            DateTime endDate)
+        {
+            using (var connection = _connectionFactory.GetConnection())
+            {
+                var query = @"
+                    DECLARE @idUser INT;
+                    DECLARE @timezone INT;
+
+                    SELECT @idUser = IdUser
+                    FROM [User]
+                    WHERE Email = @accountName;
+
+                    SELECT @timezone = timezone.offset
+                    FROM dbo.usertimezone timezone
+                    INNER JOIN dbo.[User] u ON u.idusertimezone = timezone.idusertimezone
+                    WHERE u.[Email] = @accountName;
+
+                    SELECT
+                        TPODS.IdUser,
+                        TPODS.IdThirdPartyApp,
+                        TPODS.StatsAt,
+                        TPODS.OrdersAmount,
+                        TPODS.AssistedOrderAmount,
+                        TPODS.OrdersTotal,
+                        TPODS.AssistedOrdersTotal,
+                        TPODS.Currency,
+                        TPODS.UTCAddedDate
+                    FROM [datastudio].[ThirdPartyAppOrdersDailyStat] TPODS
+                    WHERE TPODS.IdUser = @idUser
+                        AND TPODS.StatsAt >= CAST(DATEADD(MINUTE, @timezone, @startDate) AS DATE)
+                        AND TPODS.StatsAt < CAST(DATEADD(MINUTE, @timezone, @endDate) AS DATE)
+                    ORDER BY TPODS.StatsAt DESC, TPODS.IdThirdPartyApp;";
+
+                return await connection.QueryAsync<AssistedSalesSummaryItem>(
+                    query,
+                    new
+                    {
+                        accountName,
+                        startDate,
+                        endDate
+                    });
+            }
+        }
+
         #region Home Dashboard
 
         #region Audience

--- a/Doppler.ReportingApi/Models/AssistedSalesSummaryItem.cs
+++ b/Doppler.ReportingApi/Models/AssistedSalesSummaryItem.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Doppler.ReportingApi.Models
+{
+    public class AssistedSalesSummaryItem
+    {
+        public int IdUser { get; set; }
+
+        public int IdThirdPartyApp { get; set; }
+
+        public DateTime StatsAt { get; set; }
+
+        public decimal OrdersAmount { get; set; }
+
+        public decimal AssistedOrderAmount { get; set; }
+
+        public decimal OrdersTotal { get; set; }
+
+        public decimal AssistedOrdersTotal { get; set; }
+
+        public string Currency { get; set; }
+
+        public DateTime UTCAddedDate { get; set; }
+    }
+}


### PR DESCRIPTION
## Descripción

Este PR agrega un nuevo endpoint de resumen para consultar métricas de ventas asistidas por cuenta dentro de un rango de fechas.

## Cambios incluidos

- Se incorporó el endpoint `GET /{accountName}/summary/assistedsales`.
- Se validó que `startDate` y `endDate` sean obligatorios en la request.
- Se agregó la lógica en `SummaryRepository` para consultar los datos desde `datastudio.ThirdPartyAppOrdersDailyStat`.
- La consulta resuelve el `IdUser` y el timezone del usuario para filtrar correctamente el rango de fechas.
- Se creó el modelo `AssistedSalesSummaryItem` para estructurar la respuesta del endpoint.
- Se actualizó `ISummaryRepository` para exponer el nuevo método `GetAssistedSalesAsync`.
- Se agregó un test de controlador para validar que el endpoint responda `200 OK` y devuelva JSON.

## Respuesta del endpoint

La respuesta devuelve una colección de elementos con los siguientes campos:

- `IdUser`
- `IdThirdPartyApp`
- `StatsAt`
- `OrdersAmount`
- `AssistedOrderAmount`
- `OrdersTotal`
- `AssistedOrdersTotal`
- `Currency`
- `UTCAddedDate`

## Testing

- Se agregó cobertura en `SummaryControllerTest` para el nuevo endpoint.

### Checklist:

<!-- Por favor, no borrar items del checklist. El tilde significa que "lo hice" o que "puedo confirmar que mis cambios no afectan ese aspecto". -->

- [x] I have paid attention to this PR title and description
- [x] I have performed a self-review of my code
- [x] I have built it locally (or my changes does not affect the build)
- [x] I have checked all tests still run ok at Doppler.ReportingApiTest project
- [x] I have added at least one simple unit test covering the new code
